### PR TITLE
Add mentioning of baseUrl to readme.

### DIFF
--- a/README.md
+++ b/README.md
@@ -96,6 +96,15 @@ For all methods above you can adjust settings in `configuration.yml`. By default
 | **`defaultDocument`**  | String  |                   | Absolute path to default document that will be loaded automatically.                                                                          |
 | **`createNewFile`**    | String  |                   | Enable / disable new document creation.                                                                                                     |
 
+## Troubleshooting
+### How to set custom baseURL
+BaseURL is fetched from address bar however you can set custom baseURL by adding *forRoot* parameter at [app.module.ts](https://github.com/groupdocs-editor/GroupDocs.Editor-for-.NET-WebForms/blob/master/src/client/apps/editor/src/app/app.module.ts#L10)
+
+**Example:**
+```js
+EditorModule.forRoot("http://localhost:8080")
+```
+
 ## License
 The MIT License (MIT). 
 


### PR DESCRIPTION
Replicated changes from groupdocs-viewer/GroupDocs.Viewer-for-.NET-WebForms#85.